### PR TITLE
Rectify implementation of the unit normal Tag

### DIFF
--- a/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
+++ b/src/DataStructures/Tensor/EagerMath/Magnitude.hpp
@@ -38,8 +38,7 @@ Scalar<DataType> magnitude(
     const Tensor<DataType, Symmetry<1>, index_list<Index>>& vector,
     const Tensor<DataType, Symmetry<1, 1>,
                  index_list<change_index_up_lo<Index>,
-                            change_index_up_lo<Index>>>&
-        metric) noexcept {
+                            change_index_up_lo<Index>>>& metric) noexcept {
   return Scalar<DataType>{sqrt(get(dot_product(vector, vector, metric)))};
 }
 
@@ -104,6 +103,7 @@ struct Normalized : db::ComputeTag {
     }
     return vector;
   }
+  using type = typename Tag::type;
   using argument_tags = tmpl::list<Tag, Magnitude<Tag>>;
 };
 }  // namespace Tags

--- a/src/Domain/FaceNormal.hpp
+++ b/src/Domain/FaceNormal.hpp
@@ -78,53 +78,7 @@ struct UnnormalizedFaceNormal : db::ComputeTag {
       tmpl::list<Mesh<VolumeDim - 1>, ElementMap<VolumeDim, Frame>,
                  Direction<VolumeDim>>;
   using volume_tags = tmpl::list<ElementMap<VolumeDim, Frame>>;
-};
-
-template <size_t Dim, typename Frame>
-struct UnitFaceNormal : db::SimpleTag {
-  using type = tnsr::i<DataVector, Dim, Frame>;
-  static std::string name() noexcept { return "UnitFaceNormal"; }
-};
-
-template <size_t Dim, typename Frame>
-struct UnitFaceNormalCompute : UnitFaceNormal<Dim, Frame>, db::ComputeTag {
-  static constexpr auto function(
-      const db::item_type<UnnormalizedFaceNormal<Dim, Frame>>&
-          vector_in,  // Compute items need to take const references
-      const db::item_type<Magnitude<UnnormalizedFaceNormal<Dim, Frame>>>&
-          magnitude) noexcept {
-    auto vector = vector_in;
-    for (size_t d = 0; d < vector.index_dim(0); ++d) {
-      vector.get(d) /= get(magnitude);
-    }
-    return vector;
-  }
-  using argument_tags =
-      tmpl::list<UnnormalizedFaceNormal<Dim, Frame>,
-                 Magnitude<UnnormalizedFaceNormal<Dim, Frame>>>;
-  using base = UnitFaceNormal<Dim, Frame>;
-  using type = typename base::type;
-};
-
-template <size_t Dim, typename Frame>
-struct UnitFaceNormalVector : db::SimpleTag {
-  using type = tnsr::I<DataVector, Dim, Frame>;
-  static std::string name() noexcept { return "UnitFaceNormalVector"; }
-};
-
-template <size_t SpatialDim, typename Frame>
-struct UnitFaceNormalVectorCompute : UnitFaceNormalVector<SpatialDim, Frame>,
-                                     db::ComputeTag {
-  static constexpr tnsr::I<DataVector, SpatialDim, Frame> (*function)(
-      const tnsr::i<DataVector, SpatialDim, Frame>&,
-      const tnsr::II<DataVector, SpatialDim, Frame>&) =
-      &raise_or_lower_index<DataVector,
-                            SpatialIndex<SpatialDim, UpLo::Lo, Frame>>;
-  using argument_tags =
-      tmpl::list<UnitFaceNormal<SpatialDim, Frame>,
-                 gr::Tags::InverseSpatialMetric<SpatialDim, Frame, DataVector>>;
-  using base = UnitFaceNormalVector<SpatialDim, Frame>;
-  using type = typename base::type;
+  using type = tnsr::i<DataVector, VolumeDim, Frame>;
 };
 
 /// \ingroup DataBoxTagsGroup

--- a/src/Evolution/Initialization/GeneralizedHarmonicInterface.hpp
+++ b/src/Evolution/Initialization/GeneralizedHarmonicInterface.hpp
@@ -82,11 +82,8 @@ struct InterfaceForNonConservativeSystem {
                                  typename System::template magnitude_tag<
                                      Tags::UnnormalizedFaceNormal<dim>>>,
       Tags::InterfaceComputeItem<
-          Directions, Tags::Normalized<Tags::UnnormalizedFaceNormal<dim>>>,
-      Tags::InterfaceComputeItem<Directions,
-                                 Tags::UnitFaceNormalCompute<dim, Inertial>>,
-      Tags::InterfaceComputeItem<
-          Directions, Tags::UnitFaceNormalVectorCompute<dim, Inertial>>,
+          Directions,
+          ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<dim, Inertial>>>,
       Tags::InterfaceComputeItem<
           Directions,
           GeneralizedHarmonic::CharacteristicFieldsCompute<dim, Inertial>>,
@@ -133,13 +130,8 @@ struct InterfaceForNonConservativeSystem {
           GeneralizedHarmonic::Tags::ConstraintGamma2Compute<dim, Inertial>>,
       Tags::InterfaceComputeItem<
           Tags::BoundaryDirectionsExterior<dim>,
-          Tags::UnitFaceNormalCompute<dim, Frame::Inertial>>,
-      Tags::InterfaceComputeItem<
-          Tags::BoundaryDirectionsExterior<dim>,
-          Tags::UnitFaceNormalVectorCompute<dim, Frame::Inertial>>,
-      Tags::InterfaceComputeItem<
-          Tags::BoundaryDirectionsExterior<dim>,
-          Tags::Normalized<Tags::UnnormalizedFaceNormal<dim>>>,
+          ::Tags::Normalized<
+              ::Tags::UnnormalizedFaceNormal<dim, Frame::Inertial>>>,
       Tags::InterfaceComputeItem<
           Tags::BoundaryDirectionsExterior<dim>,
           GeneralizedHarmonic::CharacteristicFieldsCompute<dim, Inertial>>,

--- a/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
@@ -138,8 +138,9 @@ struct CharacteristicFieldsCompute : Tags::CharacteristicFields<Dim, Frame>,
       tmpl::list<Tags::ConstraintGamma2,
                  gr::Tags::SpacetimeMetric<Dim, Frame, DataVector>,
                  Tags::Pi<Dim, Frame>, Tags::Phi<Dim, Frame>,
-                 ::Tags::UnitFaceNormal<Dim, Frame>,
-                 ::Tags::UnitFaceNormalVector<Dim, Frame>>;
+                 ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim, Frame>>,
+                 // ::Tags::UnitFaceNormal<Dim, Frame>,
+                 gr::Tags::InverseSpatialMetric<Dim, Frame, DataVector>>;
 
   static typename Tags::CharacteristicFields<Dim, Frame>::type function(
       const Scalar<DataVector>& gamma_2,
@@ -147,7 +148,7 @@ struct CharacteristicFieldsCompute : Tags::CharacteristicFields<Dim, Frame>,
       const tnsr::aa<DataVector, Dim, Frame>& pi,
       const tnsr::iaa<DataVector, Dim, Frame>& phi,
       const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form,
-      const tnsr::I<DataVector, Dim, Frame>& unit_normal_vector) noexcept;
+      const tnsr::II<DataVector, Dim, Frame>& inverse_spatial_metric) noexcept;
 };
 
 template <size_t Dim, typename Frame>
@@ -159,7 +160,7 @@ void compute_characteristic_fields(
     const tnsr::aa<DataVector, Dim, Frame>& pi,
     const tnsr::iaa<DataVector, Dim, Frame>& phi,
     const tnsr::i<DataVector, Dim, Frame>& unit_normal_one_form,
-    const tnsr::I<DataVector, Dim, Frame>& unit_normal_vector) noexcept;
+    const tnsr::II<DataVector, Dim, Frame>& inverse_spatial_metric) noexcept;
 // @}
 
 // @{

--- a/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Equations.hpp
@@ -196,25 +196,25 @@ struct UpwindFlux {
   // Variables. Local and remote values of this data are then combined in the
   // `()` operator.
 
-  using package_tags =
-      tmpl::list<gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>,
-                 Tags::Pi<Dim, Frame::Inertial>,
-                 Tags::Phi<Dim, Frame::Inertial>, gr::Tags::Lapse<DataVector>,
-                 gr::Tags::Shift<Dim, Frame::Inertial, DataVector>,
-                 Tags::ConstraintGamma1, Tags::ConstraintGamma2,
-                 ::Tags::UnitFaceNormal<Dim, Frame::Inertial>,
-                 ::Tags::UnitFaceNormalVector<Dim, Frame::Inertial>>;
+  using package_tags = tmpl::list<
+      gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>,
+      Tags::Pi<Dim, Frame::Inertial>, Tags::Phi<Dim, Frame::Inertial>,
+      gr::Tags::Lapse<DataVector>,
+      gr::Tags::Shift<Dim, Frame::Inertial, DataVector>, Tags::ConstraintGamma1,
+      Tags::ConstraintGamma2,
+      ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim, Frame::Inertial>>,
+      gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>>;
 
   // These tags on the interface of the element are passed to
   // `package_data` to provide the data needed to compute the numerical fluxes.
-  using argument_tags =
-      tmpl::list<gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>,
-                 Tags::Pi<Dim, Frame::Inertial>,
-                 Tags::Phi<Dim, Frame::Inertial>, gr::Tags::Lapse<DataVector>,
-                 gr::Tags::Shift<Dim, Frame::Inertial, DataVector>,
-                 Tags::ConstraintGamma1, Tags::ConstraintGamma2,
-                 ::Tags::UnitFaceNormal<Dim, Frame::Inertial>,
-                 ::Tags::UnitFaceNormalVector<Dim, Frame::Inertial>>;
+  using argument_tags = tmpl::list<
+      gr::Tags::SpacetimeMetric<Dim, Frame::Inertial, DataVector>,
+      Tags::Pi<Dim, Frame::Inertial>, Tags::Phi<Dim, Frame::Inertial>,
+      gr::Tags::Lapse<DataVector>,
+      gr::Tags::Shift<Dim, Frame::Inertial, DataVector>, Tags::ConstraintGamma1,
+      Tags::ConstraintGamma2,
+      ::Tags::Normalized<::Tags::UnnormalizedFaceNormal<Dim, Frame::Inertial>>,
+      gr::Tags::InverseSpatialMetric<Dim, Frame::Inertial, DataVector>>;
 
   // pseudo-interface: used internally by Algorithm infrastructure, not
   // user-level code
@@ -232,8 +232,8 @@ struct UpwindFlux {
       const typename Tags::ConstraintGamma1::type& gamma1,
       const typename Tags::ConstraintGamma2::type& gamma2,
       const tnsr::i<DataVector, Dim, Frame::Inertial>& interface_unit_normal,
-      const tnsr::I<DataVector, Dim, Frame::Inertial>&
-          interface_unit_normal_vector) const noexcept;
+      const tnsr::II<DataVector, Dim, Frame::Inertial>& inverse_spatial_metric)
+      const noexcept;
 
   // pseudo-interface: used internally by Algorithm infrastructure, not
   // user-level code
@@ -262,8 +262,8 @@ struct UpwindFlux {
       const typename Tags::ConstraintGamma2::type& gamma2_int,
       const tnsr::i<DataVector, Dim, Frame::Inertial>&
           interface_unit_normal_int,
-      const tnsr::I<DataVector, Dim, Frame::Inertial>&
-          interface_unit_normal_vector_int,
+      const tnsr::II<DataVector, Dim, Frame::Inertial>&
+          inverse_spatial_metric_int,
       const typename gr::Tags::SpacetimeMetric<
           Dim, Frame::Inertial, DataVector>::type& spacetime_metric_ext,
       const typename Tags::Pi<Dim, Frame::Inertial>::type& pi_ext,
@@ -275,8 +275,8 @@ struct UpwindFlux {
       const typename Tags::ConstraintGamma2::type& gamma2_ext,
       const tnsr::i<DataVector, Dim, Frame::Inertial>&
           interface_unit_normal_ext,
-      const tnsr::I<DataVector, Dim, Frame::Inertial>&
-          interface_unit_normal_vector_ext) const noexcept;
+      const tnsr::II<DataVector, Dim, Frame::Inertial>&
+          inverse_spatial_metric_ext) const noexcept;
 
   // Function that performs the upwind weighting. Inputs are the char fields
   // and speeds in the interior and exterior. At each point, each returned

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/TestFunctions.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/TestFunctions.py
@@ -229,25 +229,31 @@ def char_speed_uminus(gamma1, lapse, shift, unit_normal):
 
 # Test functions for characteristic fields
 def char_field_upsi(gamma2, spacetime_metric,
-                    pi, phi, normal_one_form, normal_vector):
+                    pi, phi, normal_one_form, inverse_spatial_metric):
     return spacetime_metric
 
 
 def char_field_uzero(gamma2, spacetime_metric,
-                     pi, phi, normal_one_form, normal_vector):
+                     pi, phi, normal_one_form, inverse_spatial_metric):
+    normal_vector = np.einsum('i,ij->j', normal_one_form,\
+                              inverse_spatial_metric)
     projection_tensor = np.identity(len(normal_vector)) -\
         np.einsum('i,j', normal_one_form, normal_vector)
     return np.einsum('ij,jab->iab', projection_tensor, phi)
 
 
 def char_field_uplus(gamma2, spacetime_metric,
-                     pi, phi, normal_one_form, normal_vector):
+                     pi, phi, normal_one_form, inverse_spatial_metric):
+    normal_vector = np.einsum('i,ij->j', normal_one_form,\
+                              inverse_spatial_metric)
     phi_dot_normal = np.einsum('i,iab->ab', normal_vector, phi)
     return pi + 1*phi_dot_normal - (gamma2 * spacetime_metric)
 
 
 def char_field_uminus(gamma2, spacetime_metric,
-                      pi, phi, normal_one_form, normal_vector):
+                      pi, phi, normal_one_form, inverse_spatial_metric):
+    normal_vector = np.einsum('i,ij->j', normal_one_form,\
+                              inverse_spatial_metric)
     phi_dot_normal = np.einsum('i,iab->ab', normal_vector, phi)
     return pi - phi_dot_normal - (gamma2 * spacetime_metric)
 

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Characteristics.cpp
@@ -152,10 +152,11 @@ typename Tag::type compute_field_with_tag(
     const tnsr::aa<DataVector, Dim, Frame>& pi,
     const tnsr::iaa<DataVector, Dim, Frame>& phi,
     const tnsr::i<DataVector, Dim, Frame>& normal_one_form,
-    const tnsr::I<DataVector, Dim, Frame>& normal_vector) {
+    const tnsr::II<DataVector, Dim, Frame>& inverse_spatial_metric) {
   return get<Tag>(
       GeneralizedHarmonic::CharacteristicFieldsCompute<Dim, Frame>::function(
-          gamma_2, spacetime_metric, pi, phi, normal_one_form, normal_vector));
+          gamma_2, spacetime_metric, pi, phi, normal_one_form,
+          inverse_spatial_metric));
 }
 
 template <size_t Dim, typename Frame>
@@ -297,7 +298,7 @@ void test_characteristic_fields_analytic(
   const auto uvars = GeneralizedHarmonic::CharacteristicFieldsCompute<
       spatial_dim, Frame::Inertial>::function(gamma_2, spacetime_metric, pi,
                                               phi, unit_normal_one_form,
-                                              normal);
+                                              inverse_spatial_metric);
 
   const auto& upsi_from_func =
       get<GeneralizedHarmonic::Tags::UPsi<spatial_dim, Frame::Inertial>>(uvars);

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_UpwindFlux.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_UpwindFlux.cpp
@@ -146,20 +146,18 @@ void test_upwind_flux_analytic(
   const auto unit_normal_one_form_int = StrahlkorperGr::unit_normal_one_form(
       db::get<StrahlkorperTags::NormalOneForm<Frame::Inertial>>(box),
       one_over_one_form_magnitude_int);
-  const auto unit_normal_vector_int = raise_or_lower_index(
-      unit_normal_one_form_int, inverse_spatial_metric_int);
 
   // Get the characteristic fields and speeds
   const auto char_fields_int = GeneralizedHarmonic::CharacteristicFieldsCompute<
       spatial_dim, Frame::Inertial>::function(gamma_2, spacetime_metric_int,
                                               pi_int, phi_int,
                                               unit_normal_one_form_int,
-                                              unit_normal_vector_int);
+                                              inverse_spatial_metric_int);
   const auto char_fields_ext = GeneralizedHarmonic::CharacteristicFieldsCompute<
       spatial_dim, Frame::Inertial>::function(gamma_2, spacetime_metric_ext,
                                               pi_ext, phi_ext,
                                               unit_normal_one_form_int,
-                                              unit_normal_vector_int);
+                                              inverse_spatial_metric_int);
 
   const auto one = make_with_value<Scalar<DataVector>>(x, 1.0);
   const auto minus_one = make_with_value<Scalar<DataVector>>(x, -1.0);


### PR DESCRIPTION
## Proposed changes
In this PR we fix #1 via::
 - We replace the use of `UnitFaceNormal` with `Normalized<UnnormalizedFaceNormal>`;
 - We remove the need for `UnitFaceNormalVector` completely. This involves changes in  GH characteristics and Upwind flux.
 - We add `type` fields to several structs that need them, e.g. `Normalized`, `UnnormalizedFaceNormal`.
 - We update all executable code that depends on the above, especially `GeneralizedHarmonicInterface.hpp`
 

<!--
At a high level, describe what this PR does.
-->

### Types of changes:

- [ ] Bugfix
- [ ] New feature

### Component:

- [ ] Code
- [ ] Documentation
- [ ] Build system
- [ ] Continuous integration

### Code review checklist

- [ ] The PR passes all checks, including unit tests, `clang-tidy` and `IWYU`.
  For instructions on how to perform the CI checks locally refer to the [Dev
  guide on the Travis CI](https://spectre-code.org/travis_guide.html).
- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
